### PR TITLE
Update cabal file to compile with latest ghc

### DIFF
--- a/Wordlint.cabal
+++ b/Wordlint.cabal
@@ -44,7 +44,7 @@ extra-doc-files:    doc/Wordlint.haddock
 library
   hs-source-dirs:      src
   exposed-modules:     Text.Wordlint.Args, Text.Wordlint.Linters, Text.Wordlint.Output, Text.Wordlint.Wordpairs, Text.Wordlint.Words
-  build-depends:       base >=4.8.0.0 && <4.9.0.0, cmdargs >=0.10.0 && <0.11.0, boxes >=0.1 && <0.2
+  build-depends:       base >=4.8.0.0, cmdargs >=0.10.0 && <0.11.0, boxes >=0.1 && <0.2
   default-language:    Haskell2010
 
 executable wordlint


### PR DESCRIPTION
* Wordlint.cabal(build-depends): make package compilable
   with latest versions of GHC and LTS-12.18 stackage.

   Without this change, `stack init' fails to find suitable
   snapshot, making building package quite non-user-friendly.